### PR TITLE
Supporting patch for aad-tool compliance-check command

### DIFF
--- a/src/intune.rs
+++ b/src/intune.rs
@@ -58,7 +58,7 @@ pub struct DeviceAction {
     pub title: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct NoncompliantRule {
     #[serde(rename = "ComplianceSource")]
     pub compliance_source: Option<String>,


### PR DESCRIPTION
This patch adds new derive options to support the PR https://github.com/himmelblau-idm/himmelblau/pull/1306 which adds a compliance check command to the aad-tool